### PR TITLE
Speech granite batched inference

### DIFF
--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -47,13 +47,11 @@ class GraniteSpeechProcessor(ProcessorMixin):
 
     def __call__(
         self,
-        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
+        text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]],
         audios: Union[torch.Tensor, List[torch.Tensor]] = None,
         device: str = "cpu",
         **kwargs,
     ) -> BatchFeature:
-
-        assert text is not None, "You have to provide text"
 
         speech_inputs = {}
         text_inputs = {}

--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -48,13 +48,12 @@ class GraniteSpeechProcessor(ProcessorMixin):
     def __call__(
         self,
         text: Union[TextInput, PreTokenizedInput, List[TextInput], List[PreTokenizedInput]] = None,
-        audios: Union[np.ndarray, List[np.ndarray]] = None,
+        audios: Union[torch.Tensor, List[torch.Tensor]] = None,
         device: str = "cpu",
         **kwargs,
     ) -> BatchFeature:
 
-        if text is None and audios is None:
-            raise ValueError("You have to provide audio or text")
+        assert text is not None, "You have to provide text"
 
         speech_inputs = {}
         text_inputs = {}

--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -17,7 +17,6 @@ Processor class for Speech Granite.
 """
 from typing import List, Union
 
-import numpy as np
 import torch
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.processing_utils import ProcessorMixin
@@ -88,11 +87,15 @@ class GraniteSpeechProcessor(ProcessorMixin):
         to conveniently mask the audio features into the text embeddings.
         """
         prompt_strings = []
-        i = 0
+        num_replaced = 0
         for sample in text:
             while self.audio_token in sample:
-                sample = sample.replace(self.audio_token, "<placeholder>" * num_audio_features[i], 1)
-                i += 1
+                sample = sample.replace(
+                    self.audio_token,
+                    "<placeholder>" * num_audio_features[num_replaced],
+                    1,
+                )
+                num_replaced += 1
             prompt_strings.append(sample)
         
         prompt_strings = [sample.replace("<placeholder>", self.audio_token) for sample in prompt_strings]

--- a/src/transformers/models/granite_speech/processing_granite_speech.py
+++ b/src/transformers/models/granite_speech/processing_granite_speech.py
@@ -83,19 +83,21 @@ class GraniteSpeechProcessor(ProcessorMixin):
         text_inputs = self.tokenizer(text, padding=True, **kwargs)
         return BatchFeature(data={**text_inputs, **speech_inputs})
 
-    def _expand_audio_placeholders(self, text: list[str], num_audio_features: int):
+    def _expand_audio_placeholders(self, text: list[str], num_audio_features: List[int]):
         """
         Expands audio placeholders in the formatted text to match the number of
         features of the corresponding embeddings; we can use the resulting text
         to conveniently mask the audio features into the text embeddings.
         """
         prompt_strings = []
+        i = 0
         for sample in text:
             while self.audio_token in sample:
-                # todo: (Avihu): this assumes all audios have the same length.
-                sample = sample.replace(self.audio_token, "<placeholder>" * num_audio_features, 1)
-                prompt_strings.append(sample)
-            prompt_strings = [sample.replace("<placeholder>", self.audio_token) for sample in prompt_strings]
+                sample = sample.replace(self.audio_token, "<placeholder>" * num_audio_features[i], 1)
+                i += 1
+            prompt_strings.append(sample)
+        
+        prompt_strings = [sample.replace("<placeholder>", self.audio_token) for sample in prompt_strings]
         return prompt_strings
 
     ##### Validation

--- a/tests/models/granite_speech/test_processor_granite_speech.py
+++ b/tests/models/granite_speech/test_processor_granite_speech.py
@@ -69,8 +69,8 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor.to_json_string())
         self.assertIsInstance(processor.feature_extractor, GraniteSpeechFeatureExtractor)
 
-    def test_requires_audio_or_text(self):
-        """Ensure we require at audio, text, or both."""
+    def test_requires_text(self):
+        """Ensure we require text"""
         tokenizer = self.get_tokenizer()
         feature_extractor = self.get_feature_extractor()
         processor = GraniteSpeechProcessor(
@@ -78,8 +78,8 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
             feature_extractor=feature_extractor,
         )
 
-        with pytest.raises(ValueError):
-            processor(text=None, audios=None)
+        with pytest.raises(TypeError):
+            processor(text=None)
 
     def test_bad_text_fails(self):
         """Ensure we gracefully fail if text is the wrong type."""
@@ -152,7 +152,7 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
 
         # Make sure the number of audio tokens matches the number of features
         num_expected_features = processor.feature_extractor._get_num_audio_features(
-            inputs["input_features"],
+            vec_dims[1:],
         )
         num_audio_tokens = int(torch.sum(inputs["input_ids"] == audio_token_id))
         assert num_expected_features == num_audio_tokens


### PR DESCRIPTION
allowing batched preprocessing + inference.
- allows collating a list of audios, and keeping track of original lengths
- calculating projector length for each audio
- verifying the number of audios matches the number of audio symbol
- bugfix in line 94 (original) - which added the sample within the while loop

